### PR TITLE
bug fix

### DIFF
--- a/src/entities/place/hooks.ts
+++ b/src/entities/place/hooks.ts
@@ -41,8 +41,6 @@ export function usePlaces() {
         throw new Error('인증된 사용자만 장소를 추가할 수 있습니다.');
       }
       
-      // 프로필 존재 여부 확인 및 생성 로직 (필요시)
-      
       const { data, error } = await supabase
         .from('places_of_interest')
         .insert({

--- a/src/widgets/place-map/PlaceMap.tsx
+++ b/src/widgets/place-map/PlaceMap.tsx
@@ -62,7 +62,6 @@ export function PlaceMap({
   const [map, setMap] = useState<google.maps.Map | null>(null);
   const [infoWindowData, setInfoWindowData] = useState<Place | null>(null);
   const autocompleteInputRef = useRef<HTMLInputElement>(null);
-  const [customLabel, setCustomLabel] = useState<string>('');
   const [editingInfoWindowLabel, setEditingInfoWindowLabel] = useState<boolean>(false);
   const [newInfoWindowLabel, setNewInfoWindowLabel] = useState<string>('');
   const { theme } = useTheme();
@@ -154,7 +153,7 @@ export function PlaceMap({
           is_public: false,
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString(),
-          custom_label: customLabel
+          custom_label: '',
         } as Place);
       }
       
@@ -163,7 +162,7 @@ export function PlaceMap({
         autocompleteInputRef.current.value = '';
       }
     });
-  }, [map, onPlaceAdd, customLabel, places, onPlaceSelect]);
+  }, [map, onPlaceAdd, places, onPlaceSelect]);
 
   // Autocomplete 초기화를 위한 useEffect 추가
   useEffect(() => {
@@ -325,11 +324,11 @@ export function PlaceMap({
           notes: infoWindowData.notes || '',
           rating: infoWindowData.rating || 0,
           is_public: false,
-          custom_label: customLabel || ''
+          custom_label: infoWindowData.custom_label || ''
         });
         
         setInfoWindowData(null);
-        setCustomLabel('');
+        
         if (autocompleteInputRef.current) {
           autocompleteInputRef.current.value = '';
         }
@@ -842,7 +841,7 @@ export function PlaceMap({
               <p className={`text-sm ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} line-clamp-2 mb-1`}>{infoWindowData.address}</p>
               
               {/* 라벨 추가 버튼 - 커스텀 라벨이 없을 때만 표시 */}
-              {!infoWindowData.custom_label && !editingInfoWindowLabel && onPlaceUpdate && (
+              {!infoWindowData.custom_label && !editingInfoWindowLabel && onPlaceUpdate && infoWindowData.id !== 'new' && (
                 <div className="mt-2 flex items-center">
                   <button
                     onClick={handleStartEditLabelInInfoWindow}

--- a/src/widgets/place-map/PlaceMap.tsx
+++ b/src/widgets/place-map/PlaceMap.tsx
@@ -452,11 +452,11 @@ export function PlaceMap({
     const categoryIcon = categoryIcons[place.category as keyof typeof categoryIcons] || '📍';
     const hasCustomLabel = place.custom_label && place.custom_label.trim() !== '';
     
-    // 커스텀 라벨이 있는 경우 아이콘+라벨 형태로, 없으면 아이콘만
+    // 커스텀 라벨이 있는 경우 아이콘+라벨 형태로, 없으면 원본 지명 표시
     // 라벨이 너무 길면 최대 15자까지만 표시하고 나머지는 ellipsis 처리
     const labelText = hasCustomLabel 
       ? `${categoryIcon} ${place.custom_label}`
-      : categoryIcon;
+      : `${categoryIcon} ${place.name}`;
     
     return {
       text: labelText,

--- a/src/widgets/place-map/PlaceMap.tsx
+++ b/src/widgets/place-map/PlaceMap.tsx
@@ -447,6 +447,7 @@ export function PlaceMap({
     const hasCustomLabel = place.custom_label && place.custom_label.trim() !== '';
     
     // 커스텀 라벨이 있는 경우 아이콘+라벨 형태로, 없으면 아이콘만
+    // 라벨이 너무 길면 최대 15자까지만 표시하고 나머지는 ellipsis 처리
     const labelText = hasCustomLabel 
       ? `${categoryIcon} ${place.custom_label}`
       : categoryIcon;
@@ -661,7 +662,12 @@ export function PlaceMap({
           white-space: nowrap;
           text-align: center;
           transform: translateY(-24px);
+          max-width: 150px;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
+        
+        /* CSS hover는 기존 코드에서 동작하지 않았으므로 JS 이벤트로 대체 */
         .dark .gm-style .gm-style-iw-c {
           background-color: #1f2937;
           color: #e5e7eb;
@@ -778,7 +784,7 @@ export function PlaceMap({
               {infoWindowData.custom_label && !editingInfoWindowLabel ? (
                 <>
                   <div className="flex items-center">
-                    <h3 className="text-lg font-semibold truncate text-blue-800 dark:text-blue-200">{infoWindowData.custom_label}</h3>
+                    <h3 className="text-lg font-semibold text-blue-800 dark:text-blue-200">{infoWindowData.custom_label}</h3>
                     {onPlaceUpdate && (
                       <button
                         onClick={handleStartEditLabelInInfoWindow}
@@ -804,6 +810,7 @@ export function PlaceMap({
                     onChange={(e) => setNewInfoWindowLabel(e.target.value)}
                     className={`text-lg font-semibold p-0.5 border rounded w-[60%] ${theme === 'dark' ? 'bg-gray-700 border-gray-600 text-white' : ''}`}
                     placeholder="라벨 입력..."
+                    maxLength={100}
                     autoFocus
                   />
                   <div className="flex-shrink-0 flex ml-1">
@@ -877,6 +884,7 @@ export function PlaceMap({
                       })}
                       className={`w-full p-1 border rounded text-sm ${theme === 'dark' ? 'bg-gray-700 border-gray-600 text-white' : ''}`}
                       placeholder="장소의 별명이나 메모를 적어주세요"
+                      maxLength={100}
                     />
                   </div>
                   

--- a/src/widgets/place-map/PlaceMap.tsx
+++ b/src/widgets/place-map/PlaceMap.tsx
@@ -305,6 +305,12 @@ export function PlaceMap({
     console.log('맵 중심 좌표:', map.getCenter()?.toJSON());
     console.log('맵 줌 레벨:', map.getZoom());
   }, []);
+
+  const onMapClick = useCallback(() => {
+    if (infoWindowData) {
+      setInfoWindowData(null);
+    }
+  }, [infoWindowData]);
   
   // 새 장소 추가
   const handleAddPlace = async () => {
@@ -725,6 +731,7 @@ export function PlaceMap({
         }
         zoom={13}
         onLoad={onMapLoad}
+        onClick={onMapClick}
         options={{
           mapTypeControl: false,
           fullscreenControl: false,


### PR DESCRIPTION
## 맵 클릭으로 장소를 추가하는 기능 제거
사용자가 장소 추가를 하려고 맵의 특정 영역을 클릭했을 때보다, 이동이나 기타 다른 동작을 위해서 클릭하는 경우가 많음. 특정 랜드마크를 클릭하는 경우가 아니라면, 해당 동작이 편리한 기능이 아닌 오동작으로 여겨질 소지가 있음. 

## 커스텀 라벨의 최대 넓이 지정
모바일 환경에서 커스텀 라벨의 넓이가 너무 길 경우, 지도 화면을 가로지르는 거대한 라벨이 표시되어 심리적인 불편함을 느낄 수 있음. 커스텀 라벨 길이를 100자로 제한하고, 지도 화면에 표시되는 커스텀 라벨의 넓이를 150px로 고정함. 

## 지도에 infoWindow가 표시되어있는 경우, 지도를 클릭했을 시 infoWindow를 닫도록 수정
드래그 시 닫으려고 했으나, 상태 변경으로 인한 리렌더링이 발생하여 사용자 동작이 끊어지는 현상이 발생함. 이를 방지하고자 우선적으로 맵을 터치했을 시, infoWindow가 표시되어있는 경우 infoWindow를 닫도록 처리함.

## 커스텀 라벨이 설정되지 않은 경우 지도의 마커에 원본 지명이 표시되도록 수정
기존에는 커스텀 라벨이 설정되지 않은 경우 아이콘만 표시되고 있었음. 그러나 사용자가 커스텀 라벨을 별도로 표시하지 않았다는 얘기는 원본 지명으로도 충분히 식별이 가능하다는 의미일 가능성이 크므로, 지도의 마커에 원본 지명이 표시되도록 수정함.

## 새로운 장소를 추가할 때 커스텀 라벨 관련된 기능이 정상 동작하도록 수정
새로운 장소를 추가할 때 infoWindow에 '라벨 수정' 버튼이 표시되지만, 실제로 데이터베이스(Supabase)에는 존재하지 않으므로 라벨 수정이 정상적으로 동작하지 않음. 따라서 새로운 장소 추가시 '라벨 수정' 버튼은 숨김처리하도록 수정함.

또한, 라벨을 수정하더라도 handleAddPlace() 함수 내에서 onPlaceAdd() 훅을 실행할 때 customLabel 상태값을 전달하고 있는데, 실제로 라벨 추가시에는 customLabel 상태값을 업데이트하지 않고 있음. 실제로 업데이트하는 상태값은 infoWindowData.custom_label이므로, onPlaceAdd() 훅을 실행할 때 infoWindowData.custom_label값을 전달하도록 수정함.